### PR TITLE
fix for fedora 31

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,6 @@ TFLITE=$(TFBASE)/tensorflow/lite/tools/make/
 # ./download_dependencies.sh && ./build_lib.sh
 
 deepseg: deepseg.cc loopback.cc
-	g++ $^ -O3 -I $(TFBASE) -I $(TFLITE)/downloads/flatbuffers/include/ -L $(TFLITE)/gen/linux_x86_64/lib/ $(shell pkg-config --libs --cflags opencv) -Wall -ltensorflow-lite -lrt -ldl -pthread -o $@
+	g++ $^ -Ofast -march=native -fno-trapping-math -fassociative-math -funsafe-math-optimizations \
+	-I $(TFBASE) -I $(TFLITE)/downloads/flatbuffers/include/ -I $(TFLITE)/downloads/absl -L $(TFLITE)/gen/linux_x86_64/lib/ \
+	$(shell pkg-config --libs --cflags opencv) -Wall -ltensorflow-lite -lrt -ldl -pthread -o $@

--- a/deepseg.cc
+++ b/deepseg.cc
@@ -100,7 +100,7 @@ int main(int argc, char* argv[]) {
 
   cap.set(CV_CAP_PROP_FRAME_WIDTH,  width);
   cap.set(CV_CAP_PROP_FRAME_HEIGHT, height);
-  cap.set(CV_CAP_PROP_FOURCC, *((uint32_t*)"YUYV"));
+  cap.set(CV_CAP_PROP_MODE, CV_CAP_MODE_YUYV);
   cap.set(CV_CAP_PROP_CONVERT_RGB, false);
 
   // Load model


### PR DESCRIPTION
probably necessary because OpenCV stock package version is opencv-3.4.8
and compiler performance optimization flags