### PR TITLE
Better capture device support

### DIFF
--- a/deepseg.cc
+++ b/deepseg.cc
@@ -27,28 +27,6 @@ limitations under the License.
 
 #include "loopback.h"
 
-// OpenCV helper functions
-cv::Mat convert_rgb_to_yuyv( cv::Mat input ) {
-	cv::Mat tmp;
-	cv::cvtColor(input,tmp,CV_RGB2YUV);
-	std::vector<cv::Mat> yuv;
-	cv::split(tmp,yuv);
-	cv::Mat yuyv(tmp.rows, tmp.cols, CV_8UC2);
-	uint8_t* outdata = (uint8_t*)yuyv.data;
-	uint8_t* ydata = (uint8_t*)yuv[0].data;
-	uint8_t* udata = (uint8_t*)yuv[1].data;
-	uint8_t* vdata = (uint8_t*)yuv[2].data;
-	for (unsigned int i = 0; i < yuyv.total(); i += 2) {
-		uint8_t u = (uint8_t)(((int)udata[i]+(int)udata[i+1])/2);
-		uint8_t v = (uint8_t)(((int)vdata[i]+(int)vdata[i+1])/2);
-		outdata[2*i+0] = ydata[i+0];
-		outdata[2*i+1] = v;
-		outdata[2*i+2] = ydata[i+1];
-		outdata[2*i+3] = u;
-	}
-	return yuyv;
-}
-
 // Tensorflow Lite helper functions
 using namespace tflite;
 
@@ -81,6 +59,30 @@ cv::Mat getTensorMat(int tnum, int debug) {
 
 // deeplabv3 classes
 std::vector<std::string> labels = { "background", "aeroplane", "bicycle", "bird", "boat", "bottle", "bus", "car", "cat", "chair", "cow", "dining table", "dog", "horse", "motorbike", "person", "potted plant", "sheep", "sofa", "train", "tv" };
+
+typedef struct {
+	cv::VideoCapture *cap;
+	cv::Mat *frm;
+	int64 cnt;
+	pthread_mutex_t lock;
+} capinfo_t;
+
+void *grab_thread(void *arg) {
+	capinfo_t *ci = (capinfo_t *)arg;
+	bool done = false;
+	// while we have a capture frame.. grab frames
+	while (!done) {
+		ci->cap->grab();
+		pthread_mutex_lock(&ci->lock);
+		if (ci->frm!=NULL)
+			ci->cap->retrieve(*ci->frm);
+		else
+			done = true;
+		ci->cnt++;
+		pthread_mutex_unlock(&ci->lock);
+	}
+	return NULL;
+}
 
 int main(int argc, char* argv[]) {
 
@@ -126,18 +128,34 @@ int main(int argc, char* argv[]) {
 	printf("back:   %s\n", back);
 	printf("threads:%d\n", threads);
 
+	// read background into raw BGR24 format, resize to output
 	cv::Mat bg = cv::imread(back);
 	cv::resize(bg,bg,cv::Size(width,height));
-	bg = convert_rgb_to_yuyv( bg );
+	// open loopback virtual camera stream, assumes YUV420p output
 	int lbfd = loopback_init(vcam,width,height,debug);
 
-	cv::VideoCapture cap(ccam, CV_CAP_V4L2);
+	// check for local device name and ensure using V4L2, set capture props,
+	// otherwise assume URL and allow OpenCV to choose the right backend,
+	// finally, always enable RGB (actually BGR24) conversion so we have sane input
+	// https://github.com/opencv/opencv/blob/master/modules/videoio/src/cap_v4l.cpp#1525
+	cv::VideoCapture cap;
+	int capw, caph;
+	if (strncmp(ccam, "/dev/video", 10)==0) {
+		cap.open(ccam, CV_CAP_V4L2);
+		cap.set(CV_CAP_PROP_FRAME_WIDTH,  capw=width);
+		cap.set(CV_CAP_PROP_FRAME_HEIGHT, caph=height);
+		// don't care now we are forcing RGB out of capture
+		//cap.set(CV_CAP_PROP_FOURCC, *((uint32_t*)"YUYV"));
+		cap.set(CV_CAP_PROP_CONVERT_RGB, true);
+	} else {
+		cap.open(ccam);
+		cap.set(CV_CAP_PROP_CONVERT_RGB, true);
+		printf("stream info:\n");
+		printf("  width:  %d\n", capw=(int)cap.get(CV_CAP_PROP_FRAME_WIDTH));
+		printf("  height: %d\n", caph=(int)cap.get(CV_CAP_PROP_FRAME_HEIGHT));
+	}
 	TFLITE_MINIMAL_CHECK(cap.isOpened());
 
-	cap.set(CV_CAP_PROP_FRAME_WIDTH,  width);
-	cap.set(CV_CAP_PROP_FRAME_HEIGHT, height);
-	cap.set(CV_CAP_PROP_FOURCC, *((uint32_t*)"YUYV"));
-	cap.set(CV_CAP_PROP_CONVERT_RGB, false);
 
 	// Load model
 	std::unique_ptr<tflite::FlatBufferModel> model =
@@ -174,22 +192,46 @@ int main(int argc, char* argv[]) {
 	const int cnum = labels.size();
 	const int pers = std::find(labels.begin(),labels.end(),"person") - labels.begin();
 
+	// kick off separate grabber thread to keep OpenCV/FFMpeg happy (or it lags badly)
+	pthread_t grabber;
+	cv::Mat frm;
+	capinfo_t capinfo = { &cap, &frm, 0, PTHREAD_MUTEX_INITIALIZER };
+	if (pthread_create(&grabber, NULL, grab_thread, &capinfo)) {
+		perror("creating grabber thread");
+		exit(1);
+	}
+	// wait for first frame
+	while (0==capinfo.cnt)
+		usleep(1000);
+
+	// stats
+	int64 es = cv::getTickCount();
+	int64 e1 = es;
+	int64 fr = 0;
 	while (true) {
 
-		int e1 = cv::getTickCount();
-
-		// capture image, get square ROI
-		cv::Mat raw; cap >> raw;
+		// copy out current frame from capture thread
+		cv::Mat raw;
+		pthread_mutex_lock(&capinfo.lock);
+		capinfo.frm->copyTo(raw);
+		pthread_mutex_unlock(&capinfo.lock);
+		// resize to output if required
+		if (capw != width || caph != height)
+			cv::resize(raw,raw,cv::Size(width,height));
 		cv::Mat roi = raw(roidim);
-
-		// resize ROI to input size
-		cv::Mat in_u8_yuv, in_u8_rgb;
-		cv::resize(roi,in_u8_yuv,cv::Size(input.rows,input.cols));
-		cv::cvtColor(in_u8_yuv,in_u8_rgb,CV_YUV2RGB_YUYV);
+		// convert BGR to RGB, resize ROI to input size
+		cv::Mat in_u8_rgb, in_resized;
+		cv::cvtColor(roi,in_u8_rgb,CV_BGR2RGB);
 		// TODO: can convert directly to float?
+		cv::resize(in_u8_rgb,in_resized,cv::Size(input.cols,input.rows));
 
 		// convert to float and normalize values to [-1;1]
-		in_u8_rgb.convertTo(input,CV_32FC3,1.0/128.0,-1.0);
+		in_resized.convertTo(input,CV_32FC3,1.0/128.0,-1.0);
+
+		if (debug>1) {
+			cv::imshow("Deepseg:input", in_resized);
+			if (cv::waitKey(1) == 'q') break;
+		}
 
 		// Run inference
 		TFLITE_MINIMAL_CHECK(interpreter->Invoke() == kTfLiteOk);
@@ -218,30 +260,36 @@ int main(int argc, char* argv[]) {
 		cv::erode(tmpbuf,ofinal,element);
 
 		// scale up into full-sized mask
-		cv::resize(ofinal,mroi,cv::Size(raw.rows,raw.rows));
+		cv::resize(ofinal,mroi,cv::Size(mroi.cols,mroi.rows));
 
 		// copy background over raw cam image using mask
 		bg.copyTo(raw,mask);
 
 		// write frame to v4l2loopback
-		int framesize = raw.step[0]*raw.rows;
-		int ret = write(lbfd,raw.data,framesize);
+		cv::Mat yuv;
+		cv::cvtColor(raw,yuv,CV_BGR2YUV_I420);
+		int framesize = yuv.step[0]*yuv.rows;
+		int ret = write(lbfd,yuv.data,framesize);
 		TFLITE_MINIMAL_CHECK(ret == framesize);
+		++fr;
 
 		if (!debug) { printf("."); fflush(stdout); continue; }
 
-		int e2 = cv::getTickCount();
-		float t = (e2-e1)/cv::getTickFrequency();
-		printf("\relapsed:%f   ",t);
+		int64 e2 = cv::getTickCount();
+		float el = (e2-e1)/cv::getTickFrequency();
+		float t = (e2-es)/cv::getTickFrequency();
+		e1 = e2;
+		printf("\relapsed:%0.3f gr=%ld fr=%ld fps:%3.1f   ", el, capinfo.cnt, fr, fr/t);
 		fflush(stdout);
-		if (debug < 2) continue;
-
-		cv::Mat test;
-		cv::cvtColor(raw,test,CV_YUV2BGR_YUYV);
-		cv::imshow("output.png",test);
-		if (cv::waitKey(1) == 'q') break;
+		if (debug > 1) {
+			cv::imshow("Deepseg:output",raw);
+			if (cv::waitKey(1) == 'q') break;
+		}
 	}
+	pthread_mutex_lock(&capinfo.lock);
+	capinfo.frm = NULL;
+	pthread_mutex_unlock(&capinfo.lock);
 
-  return 0;
+	return 0;
 }
 

--- a/loopback.cc
+++ b/loopback.cc
@@ -27,8 +27,8 @@ int loopback_init(const char* device, int w, int h, int debug) {
 	struct v4l2_capability vid_caps;
 	struct v4l2_format vid_format;
 
-	size_t linewidth = w * 2;
-	size_t framesize = h * linewidth;
+	// YUV420 = 1 byte per pixel
+	size_t framesize = w * h;
 
 	int fdwr = 0;
 	int ret_code = 0;
@@ -47,10 +47,10 @@ int loopback_init(const char* device, int w, int h, int debug) {
 	vid_format.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
 	vid_format.fmt.pix.width = w;
 	vid_format.fmt.pix.height = h;
-	vid_format.fmt.pix.pixelformat = V4L2_PIX_FMT_YUYV;
+	vid_format.fmt.pix.pixelformat = V4L2_PIX_FMT_YUV420;
 	vid_format.fmt.pix.sizeimage = framesize;
 	vid_format.fmt.pix.field = V4L2_FIELD_NONE;
-	vid_format.fmt.pix.bytesperline = linewidth;
+	vid_format.fmt.pix.bytesperline = w;
 	vid_format.fmt.pix.colorspace = V4L2_COLORSPACE_SRGB;
 
 	ret_code = ioctl(fdwr, VIDIOC_S_FMT, &vid_format);


### PR DESCRIPTION
Improving capture from IP cameras / phone apps, supporting multiple capture formats:

 * enables CV_CAP_PROP_CONVERT_RGB (actually BGR24, thanks OpenCV!), allowing many devices to work without us knowing exactly what they spit out and handling conversion.
 * background images now usable without colour space conversion (as default is BGR24 too).
 * resizes capture -> output, in case capture devices are weird (eg: mjpeg from my phone is two pixels off at 638x478??)
 * ~~captures in a separate thread to avoid video lag if TF isn't quick enough (it usually isn't!)~~

I've had a fun Saturday ;)