### PR TITLE
Remove asserts

### DIFF
--- a/deepseg.cc
+++ b/deepseg.cc
@@ -235,6 +235,10 @@ int main(int argc, char* argv[]) {
 	bg = convert_rgb_to_yuyv( bg );
 
 	int lbfd = loopback_init(vcam,width,height,debug);
+	if(lbfd < 0) {
+		fprintf(stderr, "Failed to initialize vcam device.\n");
+		exit(1);
+	}
 
 	cv::VideoCapture cap(ccam, CV_CAP_V4L2);
 	TFLITE_MINIMAL_CHECK(cap.isOpened());

--- a/loopback.cc
+++ b/loopback.cc
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <assert.h>
+#include <errno.h>
 
 #include "loopback.h"
 
@@ -41,7 +42,11 @@ int loopback_init(const char* device, int w, int h, int debug) {
 	}
 
 	ret_code = ioctl(fdwr, VIDIOC_QUERYCAP, &vid_caps);
-	assert(ret_code != -1);
+	if(ret_code < 0) {
+		fprintf(stderr, "%s:%d(%s): Failed to query device capabilities: %s\n", __FILE__, __LINE__, __func__, strerror(errno));
+		close(fdwr);
+		return -1;
+	}
 
 	memset(&vid_format, 0, sizeof(vid_format));
 	//usleep(100000);
@@ -58,7 +63,11 @@ int loopback_init(const char* device, int w, int h, int debug) {
 	vid_format.fmt.pix.colorspace = V4L2_COLORSPACE_SRGB;
 
 	ret_code = ioctl(fdwr, VIDIOC_S_FMT, &vid_format);
-	assert(ret_code != -1);
+	if(ret_code < 0) {
+		fprintf(stderr, "%s:%d(%s): Failed to set device video format: %s\n", __FILE__, __LINE__, __func__, strerror(errno));
+		close(fdwr);
+		return -1;
+	}
 
 	if (debug) print_format(&vid_format);
 

--- a/loopback.cc
+++ b/loopback.cc
@@ -35,7 +35,10 @@ int loopback_init(const char* device, int w, int h, int debug) {
 	int ret_code = 0;
 
 	fdwr = open(device, O_RDWR);
-	assert(fdwr >= 0);
+	if(fdwr < 0) {
+		fprintf(stderr, "%s:%d(%s): Failed to open video device: %s\n", __FILE__, __LINE__, __func__, strerror(errno));
+		return -1;
+	}
 
 	ret_code = ioctl(fdwr, VIDIOC_QUERYCAP, &vid_caps);
 	assert(ret_code != -1);
@@ -80,6 +83,10 @@ int main(int argc, char* argv[]) {
 	}
 
 	int fdwr = loopback_init(video_device,FRAME_WIDTH,FRAME_HEIGHT);
+	if(fdwr < 0) {
+		fprintf(stderr, "Failed to initialize output device %s\n", video_device);
+		exit(1);
+	}
 
 	uint8_t* buffer = (uint8_t*)malloc(framesize);
 

--- a/loopback.cc
+++ b/loopback.cc
@@ -7,7 +7,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <fcntl.h>
-#include <assert.h>
 #include <errno.h>
 
 #include "loopback.h"


### PR DESCRIPTION
This introduces proper error messages in these situations.

Actually closes #31 and #44.