### PR TITLE
Format Conversion issues causing OpenCV exceptions

### DIFF
--- a/deepseg.cc
+++ b/deepseg.cc
@@ -245,8 +245,7 @@ int main(int argc, char* argv[]) {
 
 	cap.set(CV_CAP_PROP_FRAME_WIDTH,  width);
 	cap.set(CV_CAP_PROP_FRAME_HEIGHT, height);
-	cap.set(CV_CAP_PROP_FOURCC, *((uint32_t*)"YUYV"));
-	cap.set(CV_CAP_PROP_CONVERT_RGB, false);
+	cap.set(CV_CAP_PROP_CONVERT_RGB, true);
 
 	// Load model
 	std::unique_ptr<tflite::FlatBufferModel> model =
@@ -321,9 +320,9 @@ int main(int argc, char* argv[]) {
 		cv::Mat roi = raw(roidim);
 
 		// resize ROI to input size
-		cv::Mat in_u8_yuv, in_u8_rgb;
-		cv::resize(roi,in_u8_yuv,cv::Size(input.cols,input.rows));
-		cv::cvtColor(in_u8_yuv,in_u8_rgb,CV_YUV2RGB_YUYV);
+		cv::Mat in_u8_bgr, in_u8_rgb;
+		cv::resize(roi,in_u8_bgr,cv::Size(input.cols,input.rows));
+		cv::cvtColor(in_u8_bgr,in_u8_rgb,CV_BGR2RGB);
 		// TODO: can convert directly to float?
 
 		// bilateral filter to reduce noise

--- a/deepseg.cc
+++ b/deepseg.cc
@@ -232,7 +232,6 @@ int main(int argc, char* argv[]) {
 		bg = cv::Mat(height,width,CV_8UC3,cv::Scalar(0,255,0));
 	}
 	cv::resize(bg,bg,cv::Size(width,height));
-	bg = convert_rgb_to_yuyv( bg );
 
 	int lbfd = loopback_init(vcam,width,height,debug);
 	if(lbfd < 0) {
@@ -392,18 +391,16 @@ int main(int argc, char* argv[]) {
 		// copy background over raw cam image using mask
 		bg.copyTo(raw,mask);
 
-		if (flipHorizontal) {
-			//Horizontal mirror destroys color in YUYV, need to detour via RGB
-			cv::Mat rgb;
-			cv::cvtColor(raw,rgb,CV_YUV2BGR_YUYV);
-			cv::flip(rgb,rgb,1);
-			raw = convert_rgb_to_yuyv(rgb);
-		}
-		if (flipVertical) {
+		if (flipHorizontal && flipVertical) {
+			cv::flip(raw,raw,-1);
+		} else if (flipHorizontal) {
+			cv::flip(raw,raw,1);
+		} else if (flipVertical) {
 			cv::flip(raw,raw,0);
 		}
 
-		// write frame to v4l2loopback
+		// write frame to v4l2loopback as YUYV
+		raw = convert_rgb_to_yuyv(raw);
 		int framesize = raw.step[0]*raw.rows;
 		while (framesize > 0) {
 			int ret = write(lbfd,raw.data,framesize);


### PR DESCRIPTION
Fix for issues #46 and #47, using the OpenCV capture code to perform BGR conversion instead of trying to do it ourselves, appears to support more cameras. This also supersedes #13. 