### PR TITLE
FEATURE: Allow setting video format of input source

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Then, run deepseg (-d -d for full debug, -c for capture device, -v for virtual d
 ./deepseg -d -d -c /dev/video0 -v /dev/video1
 ```
 
+Some cameras like a *Logitec Brio* might need to switch the video source to `MJPG` by passing `-f MJPG` in order to allow for higher resolutions.
+
 ## Limitations/Extensions
 
 As usual: pull requests welcome.


### PR DESCRIPTION
It would seem some cameras need special attention. I've got a `Logitech BRIO` and it won't allow using higher resolutions, unless I use `MJPG` format as video source. `YUV` only works here for 640x480. And it would seem I need a higher resolution to get the fake webcam to work in my Chromium (88.0.4324.182).

The following patch extends the command line options to include the option `-f`. It accepts a string, which is then turned into an option of `CV_CAP_PROP_FOURCC`. 

