### PR TITLE
Build tidy up, version from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,14 @@
 # Output folder
 bin/
 
-# IDE junk
-.vscode/
+# dotfiles and folders
+.*/
+.*
+
+# temporaries
+*~
+*.bak
+*.orig
 
 # Model build bits
 models/body-pix/bodypix_*

--- a/.gitignore
+++ b/.gitignore
@@ -1,36 +1,8 @@
-# Prerequisites
-*.d
+# Output folder
+bin/
 
-# Compiled Object files
-*.slo
-*.lo
-*.o
-*.obj
+# IDE junk
+.vscode/
 
-# Precompiled Headers
-*.gch
-*.pch
-
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
-
-# Fortran module files
-*.mod
-*.smod
-
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
-
-# Executables
-*.exe
-*.out
-*.app
-
-deepseg
+# Model build bits
 models/body-pix/bodypix_*
-tv

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
 # this is licensed software, @see LICENSE file.
+
+# OpenCV & Tensorflow recommended flags for performance..
 CFLAGS = -Ofast -march=native -fno-trapping-math -fassociative-math -funsafe-math-optimizations -Wall -pthread
 LDFLAGS = -lrt -ldl
 
+# Version
+VERSION=$(shell git describe --all --always --dirty)
+CFLAGS += -D DEEPSEG_VERSION=$(VERSION)
+
 # TensorFlow
-TFBASE=tensorflow/
-TFLITE=$(TFBASE)/tensorflow/lite/tools/make/
-TFLIBS=$(TFLITE)/gen/linux_x86_64/lib/
-CFLAGS += -I $(TFBASE) -I $(TFLITE)/downloads/absl -I $(TFLITE)/downloads/flatbuffers/include -ggdb
-LDFLAGS += -L $(TFLIBS) -ltensorflow-lite -ldl
+TFBASE=tensorflow
+TFLITE=$(TFBASE)/tensorflow/lite/tools/make
+TFLIBS=$(TFLITE)/gen/linux_x86_64/lib
+TFCFLAGS += -I $(TFBASE) -I $(TFLITE)/downloads/absl -I $(TFLITE)/downloads/flatbuffers/include -ggdb
+TFLDFLAGS += -L $(TFLIBS) -ltensorflow-lite -ldl
 
 # OpenCV
 ifeq ($(shell pkg-config --exists opencv; echo $$?), 0)
@@ -20,8 +26,21 @@ else
     $(error Couldn\'t find OpenCV)
 endif
 
-deepseg: $(TFLIBS)/libtensorflow-lite.a deepseg.cc loopback.cc transpose_conv_bias.cc
-	g++ $^ ${CFLAGS} ${LDFLAGS} -o $@
+# Output folder
+BIN=bin
+
+# Default target
+all: $(BIN) $(BIN)/deepseg
+
+clean:
+	-rm -rf $(BIN)
+
+$(BIN):
+	-mkdir -p $(BIN)
+
+# Primary binary - special deps
+$(BIN)/deepseg: $(TFLIBS)/libtensorflow-lite.a deepseg.cc loopback.cc transpose_conv_bias.cc
+	g++ $^ ${CFLAGS} ${TFCFLAGS} ${LDFLAGS} ${TFLDFLAGS} -o $@
 
 $(TFLIBS)/libtensorflow-lite.a: $(TFLITE)
 	cd $(TFLITE) && ./download_dependencies.sh && ./build_lib.sh
@@ -29,10 +48,12 @@ $(TFLIBS)/libtensorflow-lite.a: $(TFLITE)
 $(TFLITE):
 	git submodule update --init --recursive
 
-all: deepseg
+# Single file test progs - OpenCV deps only
+$(BIN)/%: %.cc
+	g++ -o $@ $(CFLAGS) $^ $(LDFLAGS)
 
-clean:
-	-rm deepseg
+$(BIN)/%: %.cpp
+	g++ -o $@ $(CFLAGS) $^ $(LDFLAGS)
 
-tv: transparent_viewer.c
-	g++ -o $@ $^ -lX11 -lGL $(CFLAGS) $(LDFLAGS)
+$(BIN)/%: %.c
+	g++ -o $@ $(CFLAGS) $^ $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ LDFLAGS = -lrt -ldl
 
 # Version
 VERSION=$(shell git describe --all --long --always --dirty)
+ifeq ($(VERSION),)
+	VERSION=v0.2.0-no-git
+endif
+
 CFLAGS += -D DEEPSEG_VERSION=$(VERSION)
 
 # TensorFlow

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ LDFLAGS = -lrt -ldl
 
 # Version
 VERSION=$(shell git describe --all --long --always --dirty)
+# default if outside a git repo..
 ifeq ($(VERSION),)
 	VERSION=v0.2.0-no-git
 endif
@@ -53,11 +54,11 @@ $(TFLITE):
 	git submodule update --init --recursive
 
 # Single file test progs - OpenCV deps only
-$(BIN)/%: %.cc
-	g++ -o $@ $(CFLAGS) $^ $(LDFLAGS)
+$(BIN)/%: %.cc $(BIN)
+	g++ -o $@ $(CFLAGS) $< $(LDFLAGS)
 
-$(BIN)/%: %.cpp
-	g++ -o $@ $(CFLAGS) $^ $(LDFLAGS)
+$(BIN)/%: %.cpp $(BIN)
+	g++ -o $@ $(CFLAGS) $< $(LDFLAGS)
 
-$(BIN)/%: %.c
-	g++ -o $@ $(CFLAGS) $^ $(LDFLAGS)
+$(BIN)/%: %.c $(BIN)
+	g++ -o $@ $(CFLAGS) $< $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CFLAGS = -Ofast -march=native -fno-trapping-math -fassociative-math -funsafe-mat
 LDFLAGS = -lrt -ldl
 
 # Version
-VERSION=$(shell git describe --all --always --dirty)
+VERSION=$(shell git describe --all --long --always --dirty)
 CFLAGS += -D DEEPSEG_VERSION=$(VERSION)
 
 # TensorFlow

--- a/deepseg.cc
+++ b/deepseg.cc
@@ -2,7 +2,7 @@
  * Authors - @see AUTHORS file.
 ==============================================================================*/
 
-// tested against tensorflow lite v2.4.0 (static library)
+// tested against tensorflow lite v2.4.1 (static library)
 
 #include <unistd.h>
 #include <cstdio>
@@ -22,6 +22,11 @@
 
 #include "loopback.h"
 #include "transpose_conv_bias.h"
+
+// Due to weirdness in the C(++) preprocessor, we have to nest stringizing macros to ensure expansion
+// http://gcc.gnu.org/onlinedocs/cpp/Stringizing.html, use _STR(<raw text or macro>).
+#define __STR(X) #X
+#define _STR(X) __STR(X)
 
 int fourCcFromString(const std::string& in)
 {
@@ -303,8 +308,8 @@ void calc_mask(calcinfo_t &info, timinginfo_t &ti) {
 
 int main(int argc, char* argv[]) {
 
-	printf("deepseg v0.2.0\n");
-	printf("(c) 2021 by floe@butterbrot.org\n");
+	printf("deepseg version:%s\n", _STR(DEEPSEG_VERSION));
+	printf("(c) 2021 by floe@butterbrot.org & contributors\n");
 	printf("https://github.com/floe/deepbacksub\n");
 	timinginfo_t ti;
 	ti.bootns = timestamp();
@@ -550,7 +555,7 @@ int main(int argc, char* argv[]) {
 
 		cv::Mat test;
 		cv::cvtColor(calcinfo.raw,test,CV_YUV2BGR_YUYV);
-		cv::imshow("output.png",test);
+		cv::imshow("Deepseg:" _STR(DEEPSEG_VERSION),test);
 
 		auto keyPress = cv::waitKey(1);
 		switch(keyPress) {

--- a/deepseg.cc
+++ b/deepseg.cc
@@ -308,7 +308,7 @@ void calc_mask(calcinfo_t &info, timinginfo_t &ti) {
 
 int main(int argc, char* argv[]) {
 
-	printf("deepseg version:%s\n", _STR(DEEPSEG_VERSION));
+	printf("deepseg version %s\n", _STR(DEEPSEG_VERSION));
 	printf("(c) 2021 by floe@butterbrot.org & contributors\n");
 	printf("https://github.com/floe/deepbacksub\n");
 	timinginfo_t ti;
@@ -555,7 +555,7 @@ int main(int argc, char* argv[]) {
 
 		cv::Mat test;
 		cv::cvtColor(calcinfo.raw,test,CV_YUV2BGR_YUYV);
-		cv::imshow("Deepseg:" _STR(DEEPSEG_VERSION),test);
+		cv::imshow("DeepSeg " _STR(DEEPSEG_VERSION),test);
 
 		auto keyPress = cv::waitKey(1);
 		switch(keyPress) {


### PR DESCRIPTION
Moved from #64, these are the build changes to use a sub-folder for output files, and pass through the git version/tag/branch and a dirty flag for display.