### PR TITLE
Alpha-blending using smoothed mask

### DIFF
--- a/deepseg.cc
+++ b/deepseg.cc
@@ -79,8 +79,14 @@ cv::Mat convert_rgb_to_yuyv( cv::Mat input ) {
 cv::Mat alpha_blend(cv::Mat srca, cv::Mat srcb, cv::Mat mask) {
 	// alpha blend two (8UC3) source images using a mask (8UC1, 255=>srca, 0=>srcb), adapted from:
 	// https://www.learnopencv.com/alpha-blending-using-opencv-cpp-python/
+	// "trust no-one" => we're about to mess with data pointers
 	assert(srca.rows==srcb.rows);
 	assert(srca.cols==srcb.cols);
+	assert(mask.rows==srca.rows);
+	assert(mask.cols==srca.cols);
+	assert(srca.type()==CV_8UC3);
+	assert(srcb.type()==CV_8UC3);
+	assert(mask.type()==CV_8UC1);
 	cv::Mat out = cv::Mat::zeros(srca.size(), srca.type());
 	uint8_t *optr = (uint8_t*)out.data;
 	uint8_t *aptr = (uint8_t*)srca.data;
@@ -89,12 +95,11 @@ cv::Mat alpha_blend(cv::Mat srca, cv::Mat srcb, cv::Mat mask) {
 	int npix = srca.rows * srca.cols;
 	for (int pix=0; pix<npix; ++pix) {
 		// blending weights
-		float aw=(float)(*mptr)/255.0, bw=1.0-aw;
+		int aw=(int)(*mptr++), bw=255-aw;
 		// blend each channel byte
-		*optr = (uint8_t)( (float)(*aptr)*aw + (float)(*bptr)*bw ); ++aptr; ++bptr; ++optr;
-		*optr = (uint8_t)( (float)(*aptr)*aw + (float)(*bptr)*bw ); ++aptr; ++bptr; ++optr;
-		*optr = (uint8_t)( (float)(*aptr)*aw + (float)(*bptr)*bw ); ++aptr; ++bptr; ++optr;
-		++mptr;
+		*optr++ = (uint8_t)(( (int)(*aptr++)*aw + (int)(*bptr++)*bw )/255);
+		*optr++ = (uint8_t)(( (int)(*aptr++)*aw + (int)(*bptr++)*bw )/255);
+		*optr++ = (uint8_t)(( (int)(*aptr++)*aw + (int)(*bptr++)*bw )/255);
 	}
 	return out;
 }


### PR DESCRIPTION
Using a smoothed segmentation mask to alpha blend between background and foreground (captured video), this is a simple not-quite-light-wrapping (there is no blurred background component) fix to the hard edges we have presently. Might address #67.
For reference: https://www.premiumbeat.com/blog/what-is-light-wrapping-tips-tutorials/ provides a reasonable description of light wrapping.